### PR TITLE
Update to serde 0.6.0.

### DIFF
--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -305,10 +305,19 @@ impl<'a, Iter: 'a> de::VariantVisitor for VariantVisitor<'a, Iter>
         let ret = {
             let v = expect_val!(self.0, Text, "content");
             let v = try!(self.0.from_utf8(v));
-            KeyDeserializer::visit(v)
+            try!(KeyDeserializer::visit(v))
         };
         expect!(self.0, EndTagName(_), "end tag name");
-        ret
+        Ok(ret)
+    }
+
+    /// `visit_struct` is called when deserializing a struct-like variant
+    fn visit_struct<V>(&mut self, _fields: &'static [&'static str], mut visitor: V) -> Result<V::Value, Self::Error>
+        where V: de::Visitor,
+    {
+        expect!(self.0, StartTagClose, "start tag close");
+        let ret = try!(visitor.visit_map(ContentVisitor::new_attr(self.0)));
+        Ok(ret)
     }
 }
 

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -28,7 +28,7 @@ impl de::Deserializer for Deserializer {
         debug!("value::Deserializer::visit {:?}\n", self.value);
         let el = match self.value.take() {
             Some(value) => value,
-            None => { return Err(de::Error::end_of_stream_error()); }
+            None => { return Err(de::Error::end_of_stream()); }
         };
 
         match (el.attributes.is_empty(), el.members) {
@@ -51,7 +51,7 @@ impl de::Deserializer for Deserializer {
     {
         debug!("value::Deserializer::visit_option\n");
         if self.value.is_none() {
-            return Err(de::Error::end_of_stream_error());
+            return Err(de::Error::end_of_stream());
         };
         if self.value == Some(Element::new_empty()) {
             visitor.visit_none()
@@ -61,7 +61,7 @@ impl de::Deserializer for Deserializer {
     }
 
     #[inline]
-    fn visit_enum<V>(&mut self, _name: &str, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_enum<V>(&mut self, _name: &str, _variants: &'static [&'static str], mut visitor: V) -> Result<V::Value, Error>
         where V: de::EnumVisitor,
     {
         debug!("value::Deserializer::visit_enum\n");
@@ -76,7 +76,7 @@ impl de::Deserializer for Deserializer {
         debug!("value::Deserializer::visit_map {:?}\n", self.value);
         let el = match self.value.take() {
             Some(value) => value,
-            None => { return Err(de::Error::end_of_stream_error()); }
+            None => { return Err(de::Error::end_of_stream()); }
         };
         visitor.visit_map( MapDeserializer {
             attributes: el.attributes
@@ -110,29 +110,6 @@ impl de::VariantVisitor for VariantVisitor
     fn visit_unit(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
-
-    /// `visit_seq` is called when deserializing a tuple-like variant.
-    fn visit_seq<V>(&mut self, _visitor: V) -> Result<V::Value, Self::Error>
-        where V: de::Visitor
-    {
-        unimplemented!()
-    }
-
-    /// `visit_map` is called when deserializing a struct-like variant.
-    fn visit_map<V>(&mut self, mut visitor: V) -> Result<V::Value, Self::Error>
-        where V: de::Visitor
-    {
-        debug!("VariantVisitor::visit_map\n");
-        let el = self.0.take().unwrap();
-        visitor.visit_map(MapDeserializer {
-            attributes: el.attributes
-                          .into_iter()
-                          .map(|(k, v)| (k, v.into_iter()))
-                          .collect(),
-            state: MapDeserializerState::Inner,
-            members: el.members,
-        })
-    }
 }
 
 struct SeqDeserializer<I: Iterator<Item=Element> + ExactSizeIterator>(I);
@@ -158,7 +135,7 @@ impl<I> de::Deserializer for SeqDeserializer<I>
     }
 
     #[inline]
-    fn visit_enum<V>(&mut self, _name: &str, mut visitor: V) -> Result<V::Value, Error>
+    fn visit_enum<V>(&mut self, _name: &str, _variants: &'static [&'static str], mut visitor: V) -> Result<V::Value, Error>
         where V: de::EnumVisitor,
     {
         debug!("value::Deserializer::visit_enum\n");
@@ -199,7 +176,7 @@ impl<I> de::SeqVisitor for SeqDeserializer<I>
         if self.0.len() == 0 {
             Ok(())
         } else {
-            Err(de::Error::end_of_stream_error())
+            Err(de::Error::end_of_stream())
         }
     }
 

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -110,6 +110,40 @@ impl de::VariantVisitor for VariantVisitor
     fn visit_unit(&mut self) -> Result<(), Self::Error> {
         Ok(())
     }
+
+    fn visit_newtype<T>(&mut self) -> Result<T, Self::Error>
+        where T: de::Deserialize,
+    {
+        if let Some(element) = self.0.take() {
+            if let Content::Text(content) = element.members {
+                de::Deserialize::deserialize(&mut StringDeserializer(Some(content)))
+            }
+            else {
+                Err(Error::SyntaxError(ErrorCode::Expected("non-empty element"), 0, 0))
+            }
+        }
+        else {
+            Err(Error::SyntaxError(ErrorCode::Expected("element"), 0, 0))
+        }
+    }
+
+    fn visit_struct<V>(&mut self, _fields: &'static [&'static str], mut visitor: V) -> Result<V::Value, Self::Error>
+        where V: de::Visitor
+    {
+        if let Some(element) = self.0.take() {
+            visitor.visit_map(MapDeserializer {
+                attributes: element.attributes
+                              .into_iter()
+                              .map(|(k, v)| (k, v.into_iter()))
+                              .collect(),
+                state: MapDeserializerState::Inner,
+                members: element.members,
+            })
+        }
+        else {
+            Err(Error::SyntaxError(ErrorCode::Expected("element"), 0, 0))
+        }
+    }
 }
 
 struct SeqDeserializer<I: Iterator<Item=Element> + ExactSizeIterator>(I);

--- a/src/error.rs
+++ b/src/error.rs
@@ -7,7 +7,7 @@ use serde::de;
 use self::ErrorCode::*;
 
 /// The errors that can arise while parsing a JSON stream.
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Clone, PartialEq)]
 pub enum ErrorCode {
     EOF,
     RawValueCannotHaveAttributes,
@@ -91,19 +91,20 @@ impl From<io::Error> for Error {
 }
 
 impl de::Error for Error {
-    fn syntax_error() -> Error {
+    fn syntax(msg: &str) -> Error {
+        debug!("Syntax error: {}", msg);
         Error::SyntaxError(SerdeExpectedSomeValue, 0, 0)
     }
 
-    fn unknown_field_error(field: &str) -> Error {
+    fn unknown_field(field: &str) -> Error {
         Error::UnknownField(field.to_string())
     }
 
-    fn end_of_stream_error() -> Error {
+    fn end_of_stream() -> Error {
         Error::SyntaxError(EOF, 0, 0)
     }
 
-    fn missing_field_error(field: &'static str) -> Error {
+    fn missing_field(field: &'static str) -> Error {
         Error::MissingFieldError(field)
     }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -115,9 +115,10 @@ fn test_parse_string() {
 #[test]
 fn test_parse_enum() {
     use self::Animal::*;
+
     test_parse_ok(&[
         ("<Animal xsi:type=\"Dog\"/>", Dog),
-        //("<Animal xsi:type=\"Frog\">Quak</Animal>", Frog("Quak".to_string())),
+        ("<Animal xsi:type=\"Frog\">Quak</Animal>", Frog("Quak".to_string())),
         (
             "<Animal xsi:type=\"Cat\"><age>42</age><name>Shere Khan</name></Animal>",
             Cat {
@@ -136,6 +137,10 @@ fn test_parse_enum() {
         (
             "<Helper><x xsi:type=\"Dog\"/></Helper>",
             Helper { x: Dog },
+        ),
+        (
+            "<Helper><x xsi:type=\"Frog\">Quak</Animal></Helper>",
+            Helper { x: Frog("Quak".to_string()) },
         ),
         (
             "<Helper><x xsi:type=\"Cat\">


### PR DESCRIPTION
Add visit_newtype implementation to VariantVisitor.
Update error factory method names.
Update visit_enum method signatures.
Remove visit_named_unit and visit_named_seq from implementing visitors.
Remove visit_map and visit_seq from VariantVisitor.

This should also close issue #6.
