### PR TITLE
Upgrade to serde 0.7.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "serde_xml"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Oliver Schneider <serde-xml98198@oli-obk.de>"]
 license-file = "LICENSE"
 description = "xml support for rust-serde"
 repository = "https://github.com/serde-rs/xml"
 
 [dependencies]
-serde = "0.6"
+serde = "0.7"
 log = "0.3"
 
 [dev-dependencies]
-serde_macros = "0.6"
+serde_macros = "0.7"

--- a/src/de/value.rs
+++ b/src/de/value.rs
@@ -20,11 +20,11 @@ impl de::Deserializer for Deserializer {
     type Error = Error;
 
     #[inline]
-    fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         use self::MapDeserializerState::*;
-        debug!("value::Deserializer::visit {:?}", self.value);
+        debug!("value::Deserializer::deserialize {:?}", self.value);
         let el = match self.value.take() {
             Some(value) => value,
             None => { return Err(de::Error::end_of_stream()); }
@@ -45,10 +45,10 @@ impl de::Deserializer for Deserializer {
     }
 
     #[inline]
-    fn visit_option<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize_option<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
-        debug!("value::Deserializer::visit_option");
+        debug!("value::Deserializer::deserialize_option");
         if self.value.is_none() {
             return Err(de::Error::end_of_stream());
         };
@@ -60,24 +60,24 @@ impl de::Deserializer for Deserializer {
     }
 
     #[inline]
-    fn visit_enum<V>(&mut self, _name: &str, _variants: &'static [&'static str], mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize_enum<V>(&mut self, _name: &str, _variants: &'static [&'static str], mut visitor: V) -> Result<V::Value, Error>
         where V: de::EnumVisitor,
     {
-        debug!("value::Deserializer::visit_enum");
+        debug!("value::Deserializer::deserialize_enum");
         visitor.visit(VariantVisitor(self.value.take()))
     }
 
     #[inline]
-    fn visit_map<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize_map<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         use self::MapDeserializerState::*;
-        debug!("value::Deserializer::visit_map {:?}", self.value);
+        debug!("value::Deserializer::deserialize_map {:?}", self.value);
         let el = match self.value.take() {
             Some(value) => value,
             None => { return Err(de::Error::end_of_stream()); }
         };
-        visitor.visit_map( MapDeserializer {
+        visitor.visit_map(MapDeserializer {
             attributes: el.attributes
                           .into_iter()
                           .map(|(k, v)| (k, v.into_iter()))
@@ -152,10 +152,10 @@ impl<I> de::Deserializer for SeqDeserializer<I>
     type Error = Error;
 
     #[inline]
-    fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
-        debug!("seqdeserializer::visit");
+        debug!("seqdeserializer::deserialize");
         if let Some(el) = self.0.next() {
             debug!("el");
             de::Deserialize::deserialize(&mut Deserializer::new(el))
@@ -166,18 +166,18 @@ impl<I> de::Deserializer for SeqDeserializer<I>
     }
 
     #[inline]
-    fn visit_enum<V>(&mut self, _name: &str, _variants: &'static [&'static str], mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize_enum<V>(&mut self, _name: &str, _variants: &'static [&'static str], mut visitor: V) -> Result<V::Value, Error>
         where V: de::EnumVisitor,
     {
-        debug!("value::Deserializer::visit_enum");
+        debug!("value::Deserializer::deserialize_enum");
         visitor.visit(VariantVisitor(self.0.next()))
     }
 
     #[inline]
-    fn visit_seq<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize_seq<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
-        debug!("seqdeserializer::visit_seq");
+        debug!("seqdeserializer::deserialize_seq");
         visitor.visit_seq(self)
     }
 }
@@ -191,7 +191,7 @@ impl<I> de::SeqVisitor for SeqDeserializer<I>
     fn visit<T>(&mut self) -> Result<Option<T>, Error>
         where T: de::Deserialize
     {
-        debug!("SeqDeserializer::visit");
+        debug!("SeqDeserializer::deserialize");
         match self.0.next() {
             Some(value) => {
                 debug!("value: {:?}", value);
@@ -223,7 +223,7 @@ impl de::Deserializer for StringDeserializer {
     type Error = Error;
 
     #[inline]
-    fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         visitor.visit_string(self.0.take().unwrap())
@@ -274,13 +274,13 @@ impl de::MapVisitor for MapDeserializer {
         impl de::Deserializer for UnitDeserializer {
             type Error = Error;
 
-            fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+            fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
                 where V: de::Visitor,
             {
                 visitor.visit_unit()
             }
 
-            fn visit_option<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+            fn deserialize_option<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
                 where V: de::Visitor,
             {
                 visitor.visit_none()
@@ -321,7 +321,7 @@ impl de::Deserializer for MapDeserializer {
     type Error = Error;
 
     #[inline]
-    fn visit<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
+    fn deserialize<V>(&mut self, mut visitor: V) -> Result<V::Value, Error>
         where V: de::Visitor,
     {
         debug!("MapDeserializer!");

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,9 +91,8 @@ impl From<io::Error> for Error {
 }
 
 impl de::Error for Error {
-    fn syntax(msg: &str) -> Error {
-        debug!("Syntax error: {}", msg);
-        Error::SyntaxError(SerdeExpectedSomeValue(msg.to_string()), 0, 0)
+    fn custom<T: Into<String>>(msg: T) -> Error {
+        Error::SyntaxError(SerdeExpectedSomeValue(msg.into()), 0, 0)
     }
 
     fn unknown_field(field: &str) -> Error {

--- a/src/value.rs
+++ b/src/value.rs
@@ -34,7 +34,7 @@ impl de::Deserialize for Element {
     fn deserialize<D>(deserializer: &mut D) -> Result<Element, D::Error>
         where D: de::Deserializer,
     {
-        deserializer.visit_map(ElementVisitor)
+        deserializer.deserialize_map(ElementVisitor)
     }
 }
 
@@ -47,7 +47,7 @@ impl de::Deserialize for Helper {
     fn deserialize<D>(deserializer: &mut D) -> Result<Helper, D::Error>
         where D: de::Deserializer,
     {
-        let el = try!(deserializer.visit_map(ElementVisitor));
+        let el = try!(deserializer.deserialize_map(ElementVisitor));
         Ok(match (el.attributes.is_empty(), el.members) {
             (true, Content::Text(s)) => Helper::Text(s),
             (_, c) => Helper::Member(Element {


### PR DESCRIPTION
- Fix rename of `visit*` to `deserialize*`
- Fix rename of `Error::syntax` to `Error::custom`

When I run tests locally, I get three failures:
- test_forwarded_namespace
- test_parse_attributes
- test_parse_xml_value

All of these seem to be issues with deserializing from `Element` to the actual structure when using `serde(rename=...)`, but I'm not quite familiar enough with the intricacies to figure out what exactly is wrong. Happy to debug if you can point me in the right direction, or feel free to take the branch and iterate on it.
