### PR TITLE
don't raise a panic 'not yet implemented' for an unfinished tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 /Cargo.lock
+/.idea

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -672,6 +672,7 @@ impl<'a, Iter> de::MapVisitor for ContentVisitor<'a, Iter>
             (&Element, EmptyElementEnd(_)) => 2,
             (&Element, Text(txt)) if txt.is_ws() => 5,
             (&Element, EndTagName(_)) => return Ok(None),
+            (&Element, EndOfFile) => return Ok(None),
             _ => unimplemented!()
         } {
             0 => {

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -13,6 +13,7 @@ use std::fmt::Debug;
 
 use serde_xml::from_str;
 use serde_xml::value::{Element, from_value};
+use serde_xml::Error;
 
 use serde::de;
 use serde::ser;
@@ -840,4 +841,18 @@ fn unknown_field() {
             },
         )
     ]);
+}
+
+#[test]
+fn test_parse_unfinished() {
+    let s = "<Simple>
+                <c>abc</c>
+                <a/>
+                <b>2</b>
+                <d/>";
+
+    assert!(match from_str::<Simple>(s) {
+        Err(Error::SyntaxError(_, _, _)) => true,
+        _ => false,
+    })
 }


### PR DESCRIPTION
If xml is missing one or more finishing tags then the serde-rs lib will raise a panic 'not yet implemented'. 

EndOfFile pattern matching fixed the problem.

I added a test to check the issue.
