### PR TITLE
skip parsing a declaration <!DOCTYPE>, but not get a syntax error

### DIFF
--- a/src/de/lexer.rs
+++ b/src/de/lexer.rs
@@ -352,7 +352,7 @@ impl<Iter> XmlIterator<Iter>
                     break
                 },
                 c if c == b'<' => {
-                    return Err(BadDOCTYPE);
+                    return Err(BadProlog);
                 },
                 c => {
                     self.buf.push(c);

--- a/src/de/lexer.rs
+++ b/src/de/lexer.rs
@@ -351,7 +351,7 @@ impl<Iter> XmlIterator<Iter>
                 c if c.is_ws_or(b">") => {
                     break
                 },
-                c if c == b'<' => {
+                b'<' => {
                     return Err(BadProlog);
                 },
                 c => {
@@ -410,12 +410,12 @@ impl<Iter> XmlIterator<Iter>
 
         loop {
             match try!(self.next_char()) {
-                b'<' => {
-                    return Err(BadDOCTYPE);
-                }
                 b'>' => {
                     break;
                 },
+                b'<' => {
+                    return Err(BadDOCTYPE);
+                }
                 _ => {
                     continue;
                 }

--- a/src/de/lexer.rs
+++ b/src/de/lexer.rs
@@ -280,7 +280,7 @@ impl<Iter> XmlIterator<Iter>
         match try!(self.peek_char()) {
             b'-' => self.decode_comment(),
             b'[' => self.decode_cdata(),
-            _ if self.ch==InternalLexical::StartOfFile => self.decode_prolog(),
+            _ if self.ch == InternalLexical::StartOfFile => self.decode_prolog(),
             _ => Err(BadCommentOrCDATA),
         }
     }


### PR DESCRIPTION
1. A XML document with a DOCTYPE declaration has parsed with a syntax error BadCommentOrCDATA

I add a code to parse <!DOCTYPE>. The parsing code is for checking syntax of DOCTYPE and just skipping it.

I want to make sure this is the right approach in the lexer.
1. I add a helper function to simplify check test cases with syntax error.
