### PR TITLE
add quickcheck tests to run on the xml conformance suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,5 @@ log = "0.3"
 
 [dev-dependencies]
 serde_macros = "0.8"
+quickcheck = "0.3.1"
+glob = "0.2"

--- a/src/de/lexer.rs
+++ b/src/de/lexer.rs
@@ -267,6 +267,11 @@ impl<Iter> XmlIterator<Iter>
                 b':' => {
                     self.buf.clear();
                     self.rdr.next();
+                    let c = try!(self.next_char());
+                    if c.is_ws() {
+                        return Err(WhitespaceAfterNamespace);
+                    }
+                    self.buf.push(c);
                     continue;
                 },
                 c => {
@@ -627,4 +632,5 @@ pub enum LexerError {
     NotAHex(u8),
     EscapedNotUtf8,
     Io,
+    WhitespaceAfterNamespace,
 }

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -697,7 +697,8 @@ impl<'a, Iter> de::MapVisitor for ContentVisitor<'a, Iter>
             (&Element, Text(txt)) if txt.is_ws() => 5,
             (&Element, EndTagName(_)) => return Ok(None),
             (&Element, EndOfFile) => return Ok(None),
-            _ => unimplemented!(),
+            (&Element, Text(_)) => return Err(self.de.error(NonWhitespaceBetweenElements)),
+            _ => panic!("unimplemented: {:?}", (&self.state, try!(self.de.ch()))),
         } {
             0 => {
                 // hack for Attribute, StartTagClose

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,7 @@ pub enum ErrorCode {
     LexingError(super::de::LexerError),
     Expected(&'static str),
     XmlDoesntSupportSeqofSeq,
+    NonWhitespaceBetweenElements,
 }
 
 impl fmt::Debug for ErrorCode {
@@ -35,6 +36,7 @@ impl fmt::Debug for ErrorCode {
             Please use a newtype"
                 .fmt(f),
             ExpectedEOF => "trailing characters".fmt(f),
+            NonWhitespaceBetweenElements => "found non whitespace characters between elements".fmt(f),
         }
     }
 }

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -23,6 +23,10 @@ impl quickcheck::Arbitrary for XmlConf {
     fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
         use std::io::Read;
         let n = glob::glob("xmlconf/**/*.xml").expect("Failed to read glob pattern").filter(|e| e.is_ok()).count();
+        if n == 0 {
+            // in case no files are found
+            return XmlConf(String::new());
+        }
         loop {
             let path = glob::glob("xmlconf/**/*.xml").expect("Failed to read glob pattern").filter(|e| e.is_ok()).nth(g.gen_range(0, n)).unwrap().unwrap();
             let mut f = std::fs::File::open(&path).unwrap();

--- a/tests/quickcheck.rs
+++ b/tests/quickcheck.rs
@@ -1,0 +1,54 @@
+#![feature(custom_derive, plugin, test)]
+#![feature(custom_attribute)]
+#![plugin(serde_macros)]
+
+#[macro_use]
+extern crate log;
+
+extern crate test;
+extern crate serde;
+extern crate serde_xml;
+extern crate glob;
+
+use serde_xml::from_str;
+use serde_xml::value::Element;
+
+#[macro_use]
+extern crate quickcheck;
+
+#[derive(Clone, Debug)]
+struct XmlConf(String);
+
+impl quickcheck::Arbitrary for XmlConf {
+    fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+        use std::io::Read;
+        let n = glob::glob("xmlconf/**/*.xml").expect("Failed to read glob pattern").filter(|e| e.is_ok()).count();
+        loop {
+            let path = glob::glob("xmlconf/**/*.xml").expect("Failed to read glob pattern").filter(|e| e.is_ok()).nth(g.gen_range(0, n)).unwrap().unwrap();
+            let mut f = std::fs::File::open(&path).unwrap();
+            let mut s = String::new();
+            if f.read_to_string(&mut s).is_err() {
+                // there are files in the xmlconf suite that aren't utf8
+                continue;
+            }
+            return XmlConf(s);
+        }
+    }
+
+    fn shrink(&self) -> Box<Iterator<Item=Self>> {
+        Box::new(self.0.shrink().map(XmlConf))
+    }
+}
+
+quickcheck! {
+    fn dont_panic(s: String) -> bool {
+        let _: Result<Element, _> = from_str(&s);
+        // just check that we don't panic on any input
+        true
+    }
+    fn dont_panic2(s: XmlConf) -> bool {
+        let _: Result<Element, _> = from_str(&s.0);
+        // just check that we don't panic on any input
+        true
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -8,6 +8,7 @@ extern crate log;
 extern crate test;
 extern crate serde;
 extern crate serde_xml;
+extern crate glob;
 
 use std::fmt::Debug;
 
@@ -939,5 +940,12 @@ fn test_parse_unfinished() {
             <a/>
             <b>2</b>
             <d/>",
+    ]);
+}
+
+#[test]
+fn test_things_qc_found() {
+    test_parse_err::<u32>(&[
+        "<\u{0}:/",
     ]);
 }


### PR DESCRIPTION
The copyrights of that suite are confusing, I won't copy paste them here, but extracting the [2013 suite](https://www.w3.org/XML/Test/) into the crate folder should work. Let's see it travis doesn'tchoke without that test suite
